### PR TITLE
[FIX] Load initial countdown component

### DIFF
--- a/src/components/sections/Hero.section.tsx
+++ b/src/components/sections/Hero.section.tsx
@@ -22,6 +22,8 @@ const HeroSection: React.FC = () => {
 	}, []);
 
 	useEffect(() => {
+        calculateCountdown();
+
 		const interval = setInterval(() => {
 			calculateCountdown();
 		}, 1000);


### PR DESCRIPTION
Bug Fixed: https://github.com/LaurierHawkHacks/Landing/issues/64

The countdown appears during initial page load.

https://github.com/LaurierHawkHacks/Landing/assets/98545971/f1cb1e5b-4167-4d73-bb24-6d2e1e36103d

