### PR TITLE
fix: adding more space at FAQ section

### DIFF
--- a/src/components/Accordion/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem.tsx
@@ -30,7 +30,7 @@ const AccordionItem = (props: AccordionItemProps) => {
 
   return (
     <div className="first:border-t border-b">
-      <h2 className="text-xl font-bold uppercase text-white">
+      <h2 className="text-xl font-bold uppercase text-white leading-relaxed">
         <button
           onClick={buttonHandler}
           className="relative w-full py-5 pr-12 text-left"
@@ -61,7 +61,7 @@ const AccordionItem = (props: AccordionItemProps) => {
         role="region"
         aria-hidden={!open}
       >
-        <div className="grid gap-8 overflow-hidden">{answers}</div>
+        <div className="grid gap-6 overflow-hidden">{answers}</div>
       </div>
     </div>
   );

--- a/src/components/sections/FAQ.section.tsx
+++ b/src/components/sections/FAQ.section.tsx
@@ -2,7 +2,7 @@ import { Accordion } from "@components";
 
 const FAQSection = () => {
   return (
-    <section className="bg-midnight text-white">
+    <section className="bg-midnight text-white px-8">
       <h2 className="mb-10 text-center font-bold uppercase">
         Frequently Asked
         <span className="text-5xl font-bold text-mint"> Questions</span>


### PR DESCRIPTION
Issue: https://github.com/LaurierHawkHacks/Landing/issues/79

### How to Fix?

- Adding more white space on the sides of the FAQ section itself.
- Increase the line height of the title to make it less crowded.

### Potential Issue

- I didn't change the font size of the headers and the paragraphs. That should be solved when we set the style guide for responsive font size. 
- It might still seem crowded.

### Screen Sizes

1. **Mobile View**

![Screenshot 2024-01-22 at 11 26 17 PM](https://github.com/LaurierHawkHacks/Landing/assets/98545971/64c1b173-6319-46a5-b9f2-807669d6e091)



2. **Tablet View**
 
![Screenshot 2024-01-22 at 11 25 49 PM](https://github.com/LaurierHawkHacks/Landing/assets/98545971/e9a65eef-5760-4192-8786-94ef857e262c)



3. **Desktop View**

![Screenshot 2024-01-22 at 11 25 33 PM](https://github.com/LaurierHawkHacks/Landing/assets/98545971/c07221e8-4d0a-4527-b209-b3fa75843f69)
