### PR TITLE
fix: remove wrong font family in tailwind setting

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,6 @@
 @tailwind utilities;
 
 body {
-    font-family: 'Ralewap', system-ui, sans-serif;
     font-variant-numeric: lining-nums;
     font-feature-settings: 'lnum' 1;
     font-weight: 600;


### PR DESCRIPTION
since we have define the font family in tailwind.config.mjs, thus we don't need to set the font family in index.css again.

**tailwind.config.mjs**
```
...
fontFamily: {
                sans: ['"Raleway"', ...defaultTheme.fontFamily.sans],
            },
...
```
