### PR TITLE
Fix: navbar didn't overlap with the content below it anymore

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -22,7 +22,7 @@ const Navbar = () => {
         <nav className="gradient fixed top-0 z-50 flex h-fit w-full items-center justify-between p-8 px-10 text-white lg:justify-normal">
             <div className="logo lg:mr-8">
                 <img
-                    className="w-14"
+                    className="w-14 h-14"
                     src="./src/assets/logo.svg"
                     alt="HawkHacks Logo"
                 />

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,30 +1,25 @@
 import { useEffect, useState } from 'react';
-import { useWindowScroll } from '@uidotdev/usehooks';
 
 import Hamburger from 'hamburger-react';
 import { NavItems, Menu } from '@components';
 
 const Navbar = () => {
-    const [scrollPos] = useWindowScroll();
-    const scrollPosY = scrollPos.y as number;
-
     const [showMenu, setShowMenu] = useState(false);
 
     const hideMenu = () => setShowMenu(false);
 
     useEffect(() => {
-        if (showMenu) document.body.classList.add('overflow-y-hidden')
+        if (showMenu) document.body.classList.add('overflow-y-hidden');
         else document.body.classList.remove('overflow-y-hidden');
     }, [showMenu]);
 
     return (
-        <nav
-            className={`gradient fixed top-0 z-50 flex h-fit w-full items-center justify-between px-10 text-white lg:justify-normal ${
-                scrollPosY < 100
-                    ? 'p-8 transition-all duration-500 ease-in-out'
-                    : 'bg-midnight p-4 shadow-lg transition-all duration-500 ease-in-out'
-            }`}
-        >
+        //   ${
+        //     scrollPosY < 100
+        //         ? 'p-8 transition-all duration-500 ease-in-out'
+        //         : 'bg-midnight p-4 shadow-lg transition-all duration-500 ease-in-out'
+        // }
+        <nav className="gradient fixed top-0 z-50 flex h-fit w-full items-center justify-between p-8 px-10 text-white lg:justify-normal">
             <div className="logo lg:mr-8">
                 <img
                     className="w-14"
@@ -37,11 +32,7 @@ const Navbar = () => {
                 <NavItems isHorizontal={true} handleClick={hideMenu} />
             </div>
 
-            <div
-                className={`portal-btn hidden transition-all duration-500 ease-in-out lg:block ${
-                    scrollPosY < 100 ? 'lg:mr-32' : 'lg:mr-0'
-                }`}
-            >
+            <div className="portal-btn hidden transition-all duration-500 ease-in-out lg:mr-32 lg:block">
                 <button className="px-4 py-2 xl:px-6 xl:py-3">
                     Application Portal
                 </button>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -14,11 +14,6 @@ const Navbar = () => {
     }, [showMenu]);
 
     return (
-        //   ${
-        //     scrollPosY < 100
-        //         ? 'p-8 transition-all duration-500 ease-in-out'
-        //         : 'bg-midnight p-4 shadow-lg transition-all duration-500 ease-in-out'
-        // }
         <nav className="gradient fixed top-0 z-50 flex h-fit w-full items-center justify-between p-8 px-10 text-white lg:justify-normal">
             <div className="logo lg:mr-8">
                 <img

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -3,7 +3,11 @@ import { Navbar } from '@components';
 
 const Landing: React.FC = () => {
     return (
-        <div className="pt-36">
+        // padding calculation
+        // logo in navbar height = 3.5rem
+        // navbar adds top and bottom padding of 2rem
+        // total top padding = 3.5 + 4 = 7.5rem
+        <div className="pt-[7.5rem]">
             <Navbar />
             <FooterSection />
         </div>

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -3,7 +3,7 @@ import { Navbar } from '@components';
 
 const Landing: React.FC = () => {
     return (
-        <div>
+        <div className="pt-36">
             <Navbar />
             <FooterSection />
         </div>


### PR DESCRIPTION
Issue: https://github.com/LaurierHawkHacks/Landing/issues/115

The navbar is initially overlapping with the content below it since it is out of the document flow, and we didn't give space to separate it.  I have add a padding top hard-coded value to the component's div wrapper to prevent overlapping.

Also, I know this is off the topic, but there's an overlapping issue with the navbar MLH banner and button. I find that annoying, so I did a quick fix as well.