### PR TITLE
Feature/126/update-navbar-links-font-size

### DIFF
--- a/src/components/Navbar/NavItems.tsx
+++ b/src/components/Navbar/NavItems.tsx
@@ -29,7 +29,7 @@ const NavItems: React.FC<{
                         to={link.href}
                         offset={scrollPadding}
                         onClick={handleClick}
-                        className="link-hover--two lg:text-xl"
+                        className="link-hover--two text-xl"
                     >
                         {link.title}
                     </Link>

--- a/src/components/Navbar/NavItems.tsx
+++ b/src/components/Navbar/NavItems.tsx
@@ -19,7 +19,7 @@ const NavItems: React.FC<{
 }> = ({ isHorizontal, handleClick }) => {
     return (
         <ul
-            className={`text-deepMarine flex gap-7 ${
+            className={`flex gap-7 text-deepMarine ${
                 isHorizontal ? rowStyle : colStyle
             }`}
         >
@@ -29,7 +29,7 @@ const NavItems: React.FC<{
                         to={link.href}
                         offset={scrollPadding}
                         onClick={handleClick}
-                        className="link-hover--two"
+                        className="link-hover--two lg:text-xl"
                     >
                         {link.title}
                     </Link>


### PR DESCRIPTION
🤝https://github.com/LaurierHawkHacks/Landing/issues/126

🔍 What's Included
Updated the large screen font size to 20px. 
Font-size was 1.5rem (24px) -> now is 1.25rem (20px).
The font size never seemed to be 30px, but regardless, I think this looks great. 

📁 Files Affected:
/src/components/Navbar/NavItems.tsx

**Before:** 
![image](https://github.com/LaurierHawkHacks/Landing/assets/55710093/7deca617-3800-4d13-900d-4773d27cf846)

**After:**
![image](https://github.com/LaurierHawkHacks/Landing/assets/55710093/19c439fd-6942-4abd-a5fb-8404062fc60d)
