### PR TITLE
Fix/166/FAQ-accordion-text-highlight-fix

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -17,10 +17,9 @@ const Accordion: React.FC<AccordionProps> = ({ items }) => {
             {items.map((item, index) => (
                 <div key={index} className="px-3 w-full md:w-1/2 mb-5">
                     <div
-                        className={`cursor-pointer flex justify-between items-center p-4 bg-white border-black rounded-xl border ${
-                          activeIndex === index ? 'rounded-b-none' : ''
-                        }`}
+                        className={`cursor-pointer flex justify-between items-center p-4 bg-white border-black rounded-xl border select-none ${activeIndex === index ? 'rounded-b-none' : ''}`}
                         onClick={() => toggleAccordion(index)}
+                        role="button"
                     >
                         <h6 className="text-black">{item.question}</h6>
                         <span


### PR DESCRIPTION
🛠️[FAQ Accordion Text Highlight Fix #166](https://github.com/LaurierHawkHacks/Landing/issues/166)

🔍 **What's Included**
- Implemented `select-none` class to prevent text selection/highlighting on click within the FAQ accordion.
- Adjusted accordion item styles for consistency and improved user interaction.

📁 Files Affected:
- `src/components/Accordion.tsx`