### PR TITLE
add space between navbar and banner

### DIFF
--- a/src/components/sections/HeroStats.section.tsx
+++ b/src/components/sections/HeroStats.section.tsx
@@ -62,7 +62,7 @@ const HeroStatSection: React.FC = () => {
                         src={HawkHacksLogo}
                         alt="Hawkhacks logo"
                     />
-                    <div className="sm:space-y-2">
+                    <div className="sm:space-y-2 mt-12">
                         <h1 className="bg-gradient-to-b from-[#2B6469] to-[#00CEDB] bg-clip-text  text-4xl font-extrabold text-transparent sm:text-5.5xl lg:text-7xl xl:text-8.5xl">
                             HawkHacks 2024
                         </h1>


### PR DESCRIPTION
i felt like the navbar and banner were too close to the text before 
<img width="516" alt="Screenshot 2024-03-30 at 7 27 02 PM" src="https://github.com/LaurierHawkHacks/Landing/assets/78521390/40053039-cb59-497d-a80a-baab4d3d7982">

i added some space to make it look better
<img width="513" alt="Screenshot 2024-03-30 at 7 26 47 PM" src="https://github.com/LaurierHawkHacks/Landing/assets/78521390/36bf37d6-34ae-4f33-9600-96ca7da2b56d">
