### PR TITLE
Fix/207/missing-anchor-tags-for-sponsors-partners-navbar-items

### DIFF
--- a/src/components/sections/Sponsor.section.tsx
+++ b/src/components/sections/Sponsor.section.tsx
@@ -142,7 +142,7 @@ const SponsorFAQSection = () => {
           />
           <div className="absolute bottom-0 left-0 right-0 top-6 flex flex-col items-center space-y-6 pt-[110px] sm:space-y-12">
             <div className="absolute left-1/2 top-6 -translate-x-1/2 transform">
-              <div className="font-raleway vs:text-[60px] text-center text-[50px] font-black leading-[117px] tracking-widest text-[#404040] drop-shadow-lg sm:text-[80px]">
+              <div id="sponsors-anchor" className="font-raleway vs:text-[60px] text-center text-[50px] font-black leading-[117px] tracking-widest text-[#404040] drop-shadow-lg sm:text-[80px]">
                 SPONSORS
               </div>
             </div>
@@ -236,7 +236,7 @@ const SponsorFAQSection = () => {
             </div>
 
             <div className="mt-20" id="partners-section">
-              <div className="font-raleway vs:text-[60px] mt-6 text-center text-[50px] font-black leading-[117px] tracking-widest text-[#404040] drop-shadow-lg sm:text-[80px]">
+              <div id="partners-anchor" className="font-raleway vs:text-[60px] mt-6 text-center text-[50px] font-black leading-[117px] tracking-widest text-[#404040] drop-shadow-lg sm:text-[80px]">
                 PARTNERS
               </div>
               <div className="flex flex-wrap items-center justify-center gap-3">


### PR DESCRIPTION
🔗[Missing Anchor Tags for Sponsors/Partners Navbar Items #207](https://github.com/LaurierHawkHacks/Landing/issues/207)

🔍 **What's Included**
- Added `id` attributes for anchor links in Sponsors and Partners sections.

📁 Files Affected:
- `src/components/sections/Sponsor.section.tsx`