### PR TITLE
Fix: add more sponsor links 

### DIFF
--- a/src/utils/SponsorLinks.tsx
+++ b/src/utils/SponsorLinks.tsx
@@ -1,12 +1,45 @@
 const Links = {
-    mlh: "https://mlh.io",
-    lcs: "https://lauriercs.ca",
-    fintech: "https://wlufintech.com/",
-    fossa: "https://fossa.ca",
-    su: "https://yourstudentsunion.ca/",
+    // partners
+    mlh: 'https://mlh.io',
+    lcs: 'https://lauriercs.ca',
+    fintech: 'https://wlufintech.com/',
+    fossa: 'https://fossa.ca',
+    su: 'https://yourstudentsunion.ca/',
 
-    distributive: "https://distributive.network/",
-    near: "https://near.org/",
+    // sponsor types
+    // platinum
+    solana: 'https://solana.com/',
+    near: 'https://near.org/',
+
+    // gold
+    fantuan: 'https://fantuan.ca/delivery/en/',
+    sp: 'https://smokespoutinerie.com/',
+    domino: 'https://www.dominos.ca/en/',
+    nibiru: 'https://nibiru.fi/',
+    distributive: 'https://distributive.network/',
+
+    // silver
+    indofood: 'https://www.indofood.com/',
+    roku: 'https://www.roku.com/en-ca/',
+    slCookies: 'https://sweetlouscookies.com/',
+    cisco: 'https://www.cisco.com/site/ca/en/index.html',
+
+    // bronze
+    echo3D: 'https://www.echo3d.com/',
+    onePassword: 'https://1password.com/',
+    wolfram: 'https://www.wolframalpha.com/',
+    balsamiq: 'https://balsamiq.com/',
+    rosenfeld: 'https://rosenfeldmedia.com/',
+    taskade: 'https://www.taskade.com/',
+    streamyard: 'https://streamyard.com/',
+    defiblocks: 'https://defiblocks.io/',
+    interviewcake: 'https://www.interviewcake.com/',
+    ennios: 'https://www.enniospasta.ca/',
+    certopus: 'https://certopus.com/',
+    interviewBuddy: 'https://interviewbuddy.net/',
+    verbwire: 'https://www.verbwire.com/',
+    jdoodle: 'https://www.jdoodle.com/',
+    vectara: 'https://vectara.com/',
 };
 
 export { Links };


### PR DESCRIPTION
Issue: #247 

Todos:
- [ ] Add hover effect to sponsor's logo
- [X] Add more sponsor links to the current sponsor data

Note:
1. Since @AmirAgassi has focused on adding hyperlinks to sponsor already https://github.com/LaurierHawkHacks/Landing/issues/225, what I can do is helped him gather the data he needs.
2. Not sure what's the hover effect gonna be like, probably would be like these following simple options:
	- adding shadow
	- make the logo larger
	- border
	- make every other logo darker?
