### PR TITLE
fix: center about section on mobile

### DIFF
--- a/src/components/sections/HeroStats.section.tsx
+++ b/src/components/sections/HeroStats.section.tsx
@@ -129,7 +129,7 @@ const HeroStatSection: React.FC = () => {
                     id="about-anchor"
                     className="absolute left-1/2 top-2/3 w-2/3 -translate-x-1/2 -translate-y-1/2 transform pt-24 text-[#1D4549] sm:top-[70%] sm:pt-36 md:top-3/4 md:pt-36 "
                 >
-                    <h1 className="mb-5 pb-20 text-center text-4.5xl uppercase text-white drop-shadow-md lg:text-6.5xl xl:text-7.5xl">
+                    <h1 className="mb-6 text-center text-4.5xl uppercase text-white drop-shadow-md lg:mb-12 lg:text-6.5xl xl:mb-16 xl:text-7.5xl 2xl:mb-24">
                         About Hawkhacks
                     </h1>
                     <div className="space-y-3 text-left text-[#1D4549] lg:space-y-10">

--- a/src/components/sections/Sponsor.section.tsx
+++ b/src/components/sections/Sponsor.section.tsx
@@ -62,8 +62,9 @@ const SponsorSection = () => {
             {/* first tier */}
             <div className="max-w-[100rem]">
               <div className="mb-[2rem] flex items-center justify-center gap-6 px-3 md:gap-16 md:px-4 xl:px-6">
-                {sponsors.platinumSponsors.map((sponsor) => (
+                {sponsors.platinumSponsors.map((sponsor, i) => (
                   <a
+                    key={i}
                     href={sponsor.link}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -85,8 +86,9 @@ const SponsorSection = () => {
             {/* second tier */}
             <div className="max-w-[100rem] overflow-hidden">
               <div className="mb-[2rem] flex flex-wrap items-center justify-center gap-4 lg:gap-12">
-                {sponsors.goldSponsors.map((sponsor) => (
+                {sponsors.goldSponsors.map((sponsor, i) => (
                   <a
+                    key={i}
                     href={sponsor.link}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -108,8 +110,9 @@ const SponsorSection = () => {
             {/* third tier */}
             <div className="max-w-[100rem] overflow-hidden">
               <div className="mb-[2rem] flex flex-wrap items-center justify-center gap-8 lg:gap-12">
-                {sponsors.silverSponsors.map((sponsor) => (
+                {sponsors.silverSponsors.map((sponsor, i) => (
                   <a
+                    key={i}
                     href={sponsor.link}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -129,10 +132,11 @@ const SponsorSection = () => {
             </div>
 
             {/* fourth tier */}
-            <div className="max-w-[100rem] overflow-hidden ">
+            <div className="max-w-[100rem] overflow-hidden">
               <div className="mb-[2rem] flex flex-wrap items-center justify-center gap-8">
-                {sponsors.bronzeSponsors.map((sponsor) => (
+                {sponsors.bronzeSponsors.map((sponsor, i) => (
                   <a
+                    key={i}
                     href={sponsor.link}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -159,8 +163,9 @@ const SponsorSection = () => {
                 PARTNERS
               </h2>
               <div className="flex flex-wrap items-center justify-center gap-4">
-                {sponsors.partners.map((partner) => (
+                {sponsors.partners.map((partner, i) => (
                   <a
+                    key={i}
                     href={partner.link}
                     target="_blank"
                     rel="noopener noreferrer"


### PR DESCRIPTION
Issue: #270 
Branch: [fix/270/about-section-text-not-centered](https://github.com/LaurierHawkHacks/Landing/compare/main...fix/270/about-section-text-not-centered?expand=1)

🔍 What's Included
The issue may due to merging issue again. 
1. I only need to decrease the spacing below the heading in about section in mobile.
2. Adding key to the sponsor list to remove the warning

📁 Files Affected:
src/components/sections/HeroStats.section.tsx
src/components/sections/Sponsor.section.tsx